### PR TITLE
NRE when method is called with null parameter

### DIFF
--- a/src/NUnit.OneTimeSetup.DreddLogs/Attributes/DreddLoggingAttribute.cs
+++ b/src/NUnit.OneTimeSetup.DreddLogs/Attributes/DreddLoggingAttribute.cs
@@ -36,8 +36,12 @@ namespace NUnit.OneTimeSetup.DreddLogs.Attributes
 
         private bool IsFixtureSetupMethod(Type reflectedType, string methodName, object[] parameters)
         {
-            var types = parameters.Select(p => p.GetType()).ToArray();
-            return reflectedType.GetMethod(methodName, types).GetCustomAttribute<OneTimeSetUpAttribute>() != null;
+            if (parameters.Count() == 0)
+            {
+                return reflectedType.GetMethod(methodName, Array.Empty<Type>()).GetCustomAttribute<OneTimeSetUpAttribute>() != null;
+            }
+
+            return false;
         }
 
         private bool IsAsyncMethod(Type returnType)

--- a/tests/NUnit.OneTimeSetup.DreddLogs.Tests/NUnitTestResultTests.cs
+++ b/tests/NUnit.OneTimeSetup.DreddLogs.Tests/NUnitTestResultTests.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 namespace NUnit.OneTimeSetup.DreddLogs.Tests
 {
     [TestFixture]
-    public class Tests
+    public class NUnitTestResultTests
     {
         private ITestRunner _testRunner;
 

--- a/tests/NUnit.OneTimeSetup.DreddLogs.Tests/OverloadedMethodsTests.cs
+++ b/tests/NUnit.OneTimeSetup.DreddLogs.Tests/OverloadedMethodsTests.cs
@@ -10,9 +10,16 @@ namespace NUnit.OneTimeSetup.DreddLogs.Tests
     {
         [TestCase("hello")]
         [TestCase("world")]
-        public void ParameterizedTest(string str)
+        [TestCase(null)]
+        public void CallOverloadedMethodWithParameters(string str)
         {
             OverloadedMethod(str);
+        }
+
+        [Test]
+        public void CallOverloadedMethodWithoutParameters()
+        {
+            OverloadedMethod();
         }
 
         public void OverloadedMethod()


### PR DESCRIPTION
- fixed NullReferenceException when method was called with parameter set to null.
- renamed test suit to NUnitTestResultTests
