### PR TITLE
[Bugfix] nunit exceptions, cleaner FixtureSetupException's stacktrace

### DIFF
--- a/src/NUnit.OneTimeSetup.DreddLogs/Attributes/DreddLoggingAttribute.cs
+++ b/src/NUnit.OneTimeSetup.DreddLogs/Attributes/DreddLoggingAttribute.cs
@@ -55,7 +55,7 @@ namespace NUnit.OneTimeSetup.DreddLogs.Attributes
             {
                 return target(args);
             }
-            catch (Exception e)
+            catch (Exception e) when (!typeof(ResultStateException).IsAssignableFrom(e.GetType()))
             {
                 throw new FixtureSetupException(e);
             }

--- a/tests/NUnit.OneTimeSetup.DreddLogs.Tests.Internal/IgnoreInOneTimeSetupTests.cs
+++ b/tests/NUnit.OneTimeSetup.DreddLogs.Tests.Internal/IgnoreInOneTimeSetupTests.cs
@@ -1,0 +1,21 @@
+﻿using NUnit.Framework;
+
+namespace NUnit.OneTimeSetup.DreddLogs.Tests.Internal
+{
+    [TestFixture]
+    public class IgnoreInOneTimeSetupTests
+    {
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            Assert.Ignore();
+        }
+
+        [Test]
+        public void Test() { }
+
+        [Test]
+        public void Test1() { }
+
+    }
+}

--- a/tests/NUnit.OneTimeSetup.DreddLogs.Tests/NUnitTestResultTests.cs
+++ b/tests/NUnit.OneTimeSetup.DreddLogs.Tests/NUnitTestResultTests.cs
@@ -3,6 +3,8 @@ using FluentAssertions;
 using FluentAssertions.Execution;
 using NUnit.Engine;
 using NUnit.Framework;
+using NUnit.OneTimeSetup.DreddLogs.Attributes;
+using NUnit.OneTimeSetup.DreddLogs.Exceptions;
 using NUnit.OneTimeSetup.DreddLogs.Tests.Internal;
 
 namespace NUnit.OneTimeSetup.DreddLogs.Tests
@@ -35,6 +37,9 @@ namespace NUnit.OneTimeSetup.DreddLogs.Tests
             {
                 testCaseNodes.Count.Should().Be(testCaseCount);
 
+                var fixtureSetupExceptionFullName = typeof(FixtureSetupException).FullName;
+                var dreddLoggingAttributeFullName = typeof(DreddLoggingAttribute).FullName;
+
                 foreach (var testCaseNode in testCaseNodes)
                 {
                     var xmlNode = testCaseNode as XmlNode;
@@ -42,10 +47,13 @@ namespace NUnit.OneTimeSetup.DreddLogs.Tests
                     var isFailed = xmlNode.SelectSingleNode("./failure") is not null;
                     isFailed.Should().BeTrue();
 
+                    var exName = nameof(FixtureSetupException);
+
                     var message = xmlNode.SelectSingleNode("./failure/message").InnerText;
-                    message.Should().Contain("NUnit.OneTimeSetup.DreddLogs.Exceptions.FixtureSetupException : Exception was thrown in fixture setup")
+                    message.Should().Contain($"{fixtureSetupExceptionFullName} : Exception was thrown in fixture setup")
                                     .And.Contain("Previous logs")
-                                    .And.Contain("----> System.Exception");
+                                    .And.Contain("----> System.Exception")
+                                    .And.NotContain($"{dreddLoggingAttributeFullName}");
                 }
             }
         }


### PR DESCRIPTION
- NUnit's result state exceptions (e.g. IgnoreException) aren't caught in order not to break nunit's logic and test results
- Removed aspect-injector's autogenerated code from FixtureSetupException's stacktrace