### PR TITLE
[Bugfix] nunit exceptions, cleaner FixtureSetupException's stacktrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # NUnit.OneTimeSetup.DreddLogs
+
 [![build](https://github.com/alexsanv/NUnit.OneTimeSetup.DreddLogs/actions/workflows/build.yml/badge.svg)](https://github.com/alexsanv/NUnit.OneTimeSetup.DreddLogs/actions/workflows/build.yml)
 [![nuget](https://buildstats.info/nuget/NUnit.OneTimeSetup.DreddLogs)](https://www.nuget.org/packages/NUnit.OneTimeSetup.DreddLogs/)
 
@@ -20,16 +21,14 @@ exception's stacktrace and all the preceding logs. E.g.:
 
 ```
 OneTimeSetUp: NUnit.OneTimeSetup.DreddLogs.Exceptions.FixtureSetupException : Exception was thrown in fixture setup
-    System.Exception: <original exception's message>
-       at NUnit.OneTimeSetup.DreddLogs.Tests.TestFixtureWithSynchronousStaticSetupMethod.__a$_around_OneTimeSetup_100663307_o() in D:\Workspace\nunit-fixture-logger\tests\NUnit.OneTimeSetup.DreddLogs.Tests\TestFixtureWithSynchronousNonStaticSetupMethod.cs:line 29
-       at NUnit.OneTimeSetup.DreddLogs.Tests.TestFixtureWithSynchronousStaticSetupMethod.__a$_around_OneTimeSetup_100663307_u(Object[] )
-       at NUnit.OneTimeSetup.DreddLogs.Attributes.DreddLoggingAttribute.Wrap(Func`2 target, Object[] args) in D:\Workspace\nunit-fixture-logger\src\NUnit.OneTimeSetup.DreddLogs\Attributes\DreddLoggingAttribute.cs:line 50
+    System.Exception: Synchronous non-static fixture setup method
+       at NUnit.OneTimeSetup.DreddLogs.Internal.Tests.WithoutGlobalSetup.SyncSetup.TestFixtureWithSynchronousNonStaticSetupMethod.ThrowException() in D:\Tools\NUnit.OneTimeSetup.DreddLogs\tests\NUnit.OneTimeSetup.DreddLogs.Tests.Internal\WithoutGlobalSetup\SyncSetup\TestFixtureWithSynchronousNonStaticSetupMethod.cs:line 23
+       at NUnit.OneTimeSetup.DreddLogs.Internal.Tests.WithoutGlobalSetup.SyncSetup.TestFixtureWithSynchronousNonStaticSetupMethod.OneTimeSetup()
 
     Previous logs:
-    [21:32:02 INF] OneTimeSetup of TestFixtureWithSynchronousStaticSetupMethod
+    [19:31:24 INF] OneTimeSetup of TestFixtureWithSynchronousNonStaticSetupMethod
 
-
-      ----> System.Exception : Synchronous static fixture setup method
+      ----> System.Exception : Synchronous non-static fixture setup method
 ```
 
 ## How to use
@@ -41,14 +40,5 @@ That's it.
 ## Limitations and known issues
 
 - DreddLogging attribute does not work with inheritance. If you have some base fixture class and all other fixture classes are inherited from it, and you specify [DreddLogging] atribute in base class then it's functionality won't be inherited in derived classes. Known issue of aspect-injector - [#101](https://github.com/pamidur/aspect-injector/issues/101).
-- Stack trace contains names of wrapper methods produced by [aspect-injector](https://github.com/pamidur/aspect-injector) rather than original method names e.g. ***__a$_around_OneTimeSetup_100663307_o*** in the following stack trace:
-```
- System.Exception: <original exception's message>
-       at NUnit.OneTimeSetup.DreddLogs.Tests.TestFixtureWithSynchronousStaticSetupMethod.__a$_around_OneTimeSetup_100663307_o() in D:\Workspace\nunit-fixture-logger\tests\NUnit.OneTimeSetup.DreddLogs.Tests\TestFixtureWithSynchronousNonStaticSetupMethod.cs:line 29
-       at NUnit.OneTimeSetup.DreddLogs.Tests.TestFixtureWithSynchronousStaticSetupMethod.__a$_around_OneTimeSetup_100663307_u(Object[] )
-       at NUnit.OneTimeSetup.DreddLogs.Attributes.DreddLoggingAttribute.Wrap(Func`2 target, Object[] args) in D:\Workspace\nunit-fixture-logger\src\NUnit.OneTimeSetup.DreddLogs\Attributes\DreddLoggingAttribute.cs:line 50
-
-```
-Related issues: [#156](https://github.com/pamidur/aspect-injector/issues/156)
 
 - For all others, refer to [aspect-injector](https://github.com/pamidur/aspect-injector)

--- a/src/NUnit.OneTimeSetup.DreddLogs/Attributes/DreddLoggingAttribute.cs
+++ b/src/NUnit.OneTimeSetup.DreddLogs/Attributes/DreddLoggingAttribute.cs
@@ -55,7 +55,7 @@ namespace NUnit.OneTimeSetup.DreddLogs.Attributes
             {
                 return target(args);
             }
-            catch (Exception e)
+            catch (Exception e) when (!typeof(ResultStateException).IsAssignableFrom(e.GetType()))
             {
                 throw new FixtureSetupException(e);
             }

--- a/src/NUnit.OneTimeSetup.DreddLogs/Exceptions/FixtureSetupException.cs
+++ b/src/NUnit.OneTimeSetup.DreddLogs/Exceptions/FixtureSetupException.cs
@@ -21,6 +21,7 @@ namespace NUnit.OneTimeSetup.DreddLogs.Exceptions
                 sb.AppendLine(base.Message)
                   .AppendLine($"{InnerException.GetType().FullName}: {InnerException.Message}")
                   .AppendLine(GetPurifiedInnerExceptionStacktrace())
+                  .AppendLine()
                   .AppendLine("Previous logs:")
                   .Append(TestExecutionContext.CurrentContext.CurrentResult.Output);
 
@@ -32,8 +33,8 @@ namespace NUnit.OneTimeSetup.DreddLogs.Exceptions
         {
             var sb = new StringBuilder();
 
-            sb.AppendLine(PurifyStacktrace(StackTrace))
-              .Append(PurifyStacktrace(InnerException.StackTrace));
+            sb.AppendLine(PurifyStacktrace(InnerException.StackTrace))
+              .Append(PurifyStacktrace(StackTrace));
 
             return sb.ToString();
         }
@@ -42,7 +43,7 @@ namespace NUnit.OneTimeSetup.DreddLogs.Exceptions
         {
             var sb = new StringBuilder();
 
-            var lines = stackTrace.Split("\r\n");
+            var lines = stackTrace.Split(Environment.NewLine);
             foreach (var line in lines)
             {
                 if (!string.IsNullOrEmpty(line) && !line.Contains("$_around") && !line.Contains(typeof(DreddLoggingAttribute).FullName))
@@ -51,7 +52,7 @@ namespace NUnit.OneTimeSetup.DreddLogs.Exceptions
                 }
             }
 
-            return sb.ToString();
+            return sb.ToString().TrimEnd(Environment.NewLine.ToCharArray());
         }
     }
 }

--- a/tests/NUnit.OneTimeSetup.DreddLogs.Tests.Internal/IgnoreInOneTimeSetupTests.cs
+++ b/tests/NUnit.OneTimeSetup.DreddLogs.Tests.Internal/IgnoreInOneTimeSetupTests.cs
@@ -1,0 +1,21 @@
+﻿using NUnit.Framework;
+
+namespace NUnit.OneTimeSetup.DreddLogs.Tests.Internal
+{
+    [TestFixture]
+    public class IgnoreInOneTimeSetupTests
+    {
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            Assert.Ignore();
+        }
+
+        [Test]
+        public void Test() { }
+
+        [Test]
+        public void Test1() { }
+
+    }
+}

--- a/tests/NUnit.OneTimeSetup.DreddLogs.Tests.Internal/WithoutGlobalSetup/SyncSetup/TestFixtureWithSynchronousNonStaticSetupMethod.cs
+++ b/tests/NUnit.OneTimeSetup.DreddLogs.Tests.Internal/WithoutGlobalSetup/SyncSetup/TestFixtureWithSynchronousNonStaticSetupMethod.cs
@@ -11,11 +11,16 @@ namespace NUnit.OneTimeSetup.DreddLogs.Internal.Tests.WithoutGlobalSetup.SyncSet
         public void OneTimeSetup()
         {
             Logger.Information($"{nameof(OneTimeSetup)} of {nameof(TestFixtureWithSynchronousNonStaticSetupMethod)}");
-            throw new Exception("Synchronous non-static fixture setup method");
+            ThrowException();
         }
 
         [Test]
         public void Test()
         { }
+
+        private void ThrowException()
+        {
+            throw new Exception("Synchronous non-static fixture setup method");
+        }
     }
 }

--- a/tests/NUnit.OneTimeSetup.DreddLogs.Tests/NUnitTestResultTests.cs
+++ b/tests/NUnit.OneTimeSetup.DreddLogs.Tests/NUnitTestResultTests.cs
@@ -47,8 +47,6 @@ namespace NUnit.OneTimeSetup.DreddLogs.Tests
                     var isFailed = xmlNode.SelectSingleNode("./failure") is not null;
                     isFailed.Should().BeTrue();
 
-                    var exName = nameof(FixtureSetupException);
-
                     var message = xmlNode.SelectSingleNode("./failure/message").InnerText;
                     message.Should().Contain($"{fixtureSetupExceptionFullName} : Exception was thrown in fixture setup")
                                     .And.Contain("Previous logs")

--- a/tests/NUnit.OneTimeSetup.DreddLogs.Tests/NUnitTestResultTests.cs
+++ b/tests/NUnit.OneTimeSetup.DreddLogs.Tests/NUnitTestResultTests.cs
@@ -3,6 +3,9 @@ using FluentAssertions;
 using FluentAssertions.Execution;
 using NUnit.Engine;
 using NUnit.Framework;
+using NUnit.OneTimeSetup.DreddLogs.Attributes;
+using NUnit.OneTimeSetup.DreddLogs.Exceptions;
+using NUnit.OneTimeSetup.DreddLogs.Tests.Internal;
 
 namespace NUnit.OneTimeSetup.DreddLogs.Tests
 {
@@ -19,17 +22,23 @@ namespace NUnit.OneTimeSetup.DreddLogs.Tests
         }
 
         [Test]
-        public void SimpleTest()
+        public void ExceptionsThrownInFixtureSetup_ShouldBeWrappedByFixtureSetupException()
         {
-            var testCaseCount = _testRunner.CountTestCases(TestFilter.Empty);
+            var testFilterXml = $@"<filter><not><class>{typeof(IgnoreInOneTimeSetupTests).FullName}</class></not></filter>";
+            var filter = new TestFilter(testFilterXml);
+
+            var testCaseCount = _testRunner.CountTestCases(filter);
             testCaseCount.Should().BeGreaterThan(0);
 
-            var xmlReport = _testRunner.Run(null, TestFilter.Empty);
+            var xmlReport = _testRunner.Run(null, filter);
             var testCaseNodes = xmlReport.SelectNodes("//test-case");
 
             using (new AssertionScope())
             {
                 testCaseNodes.Count.Should().Be(testCaseCount);
+
+                var fixtureSetupExceptionFullName = typeof(FixtureSetupException).FullName;
+                var dreddLoggingAttributeFullName = typeof(DreddLoggingAttribute).FullName;
 
                 foreach (var testCaseNode in testCaseNodes)
                 {
@@ -38,10 +47,33 @@ namespace NUnit.OneTimeSetup.DreddLogs.Tests
                     var isFailed = xmlNode.SelectSingleNode("./failure") is not null;
                     isFailed.Should().BeTrue();
 
+                    var exName = nameof(FixtureSetupException);
+
                     var message = xmlNode.SelectSingleNode("./failure/message").InnerText;
-                    message.Should().Contain("NUnit.OneTimeSetup.DreddLogs.Exceptions.FixtureSetupException : Exception was thrown in fixture setup")
+                    message.Should().Contain($"{fixtureSetupExceptionFullName} : Exception was thrown in fixture setup")
                                     .And.Contain("Previous logs")
-                                    .And.Contain("----> System.Exception");
+                                    .And.Contain("----> System.Exception")
+                                    .And.NotContain($"{dreddLoggingAttributeFullName}");
+                }
+            }
+        }
+
+        [Test]
+        public void NunitResultStateExceptionsShouldNotBeCaught()
+        {
+            var testFilterXml = $@"<filter><class>{typeof(IgnoreInOneTimeSetupTests).FullName}</class></filter>";
+            var filter = new TestFilter(testFilterXml);
+
+            var xmlReport = _testRunner.Run(null, filter);
+            var testCaseNodes = xmlReport.SelectNodes("//test-case");
+
+            using (new AssertionScope())
+            {
+                foreach (var testCaseNode in testCaseNodes)
+                {
+                    var xmlNode = testCaseNode as XmlNode;
+                    var testCaseResult = xmlNode.Attributes["result"];
+                    testCaseResult.Value.Should().Be("Skipped");
                 }
             }
         }


### PR DESCRIPTION
- NUnit's result state exceptions (e.g. IgnoreException) aren't caught in order not to break nunit's logic and test results
- Removed aspect-injector's autogenerated code from FixtureSetupException's stacktrace